### PR TITLE
Update type checker to use a subclass rather than an instance.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twinkie",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/printer.ts
+++ b/printer.ts
@@ -1,6 +1,6 @@
 import { AST_NODE, AST_TREE, EXPRESSION } from "./types";
 
-export function printTree(tree: AST_TREE, interfaceName: string = "View") {
+export function printTree(tree: AST_TREE, interfaceName = "View") {
   let ret = "";
 
   ret += `export interface ${interfaceName} {\n`;
@@ -16,12 +16,12 @@ export function printTree(tree: AST_TREE, interfaceName: string = "View") {
   return ret;
 }
 
-export function printUse(tree: AST_TREE, realType: string = "View") {
+export function printUse(tree: AST_TREE, realType = "View") {
   let ret = `const viewInstance = {} as ${realType}\n`;
   for (const expressionKey of Object.keys(tree)) {
     const node = tree[expressionKey];
     ret += printNodeUse(node, 'viewInstance.');
-   }
+  }
 
   return ret;
 }
@@ -29,45 +29,45 @@ export function printUse(tree: AST_TREE, realType: string = "View") {
 function printNodeUse(node: AST_NODE, expressionPrefix = '') {
   let ret = '';
   switch (node.type) {
-      case EXPRESSION.LIST: {
-        ret += `${expressionPrefix}${node.expression}!.every\n`
-        if (node.children) {
-          for (const childNodeExpression of Object.keys(node.children)) {
-            ret += printNodeUse(node.children[childNodeExpression], `${expressionPrefix}${node.expression}!.`);
-          }
+    case EXPRESSION.LIST: {
+      ret += `${expressionPrefix}${node.expression}!.every\n`;
+      if (node.children) {
+        for (const childNodeExpression of Object.keys(node.children)) {
+          ret += printNodeUse(node.children[childNodeExpression], `${expressionPrefix}${node.expression}!.`);
         }
-        if (node.listIndexType) {
-          for (const listNodeExpression of Object.keys(node.listIndexType)) {
-            ret += printNodeUse(node.listIndexType[listNodeExpression], `${expressionPrefix}${node.expression}![0]!.`);
-          }
-        }
-
-        break;
       }
-      case EXPRESSION.VALUE: {
-        ret += `${expressionPrefix}${node.expression}!\n`
-        if (node.children) {
-          for (const childNodeExpression of Object.keys(node.children)) {
-            ret += printNodeUse(node.children[childNodeExpression], `${expressionPrefix}${node.expression}!.`);
-          }
+      if (node.listIndexType) {
+        for (const listNodeExpression of Object.keys(node.listIndexType)) {
+          ret += printNodeUse(node.listIndexType[listNodeExpression], `${expressionPrefix}${node.expression}![0]!.`);
         }
-
-        break;
       }
-      case EXPRESSION.FUNCTION: {
-        const argList = [];
-        if (node.argumentCount) {
-          for (let i = 0; i < node.argumentCount; i++) {
-            argList.push(`null!`);
-          }
-        }
-        ret += `${expressionPrefix}${node.expression}!(${argList.join(', ')})\n`
 
-        break;
-      }
+      break;
     }
+    case EXPRESSION.VALUE: {
+      ret += `${expressionPrefix}${node.expression}!\n`;
+      if (node.children) {
+        for (const childNodeExpression of Object.keys(node.children)) {
+          ret += printNodeUse(node.children[childNodeExpression], `${expressionPrefix}${node.expression}!.`);
+        }
+      }
 
-    return ret;
+      break;
+    }
+    case EXPRESSION.FUNCTION: {
+      const argList = [];
+      if (node.argumentCount) {
+        for (let i = 0; i < node.argumentCount; i++) {
+          argList.push(`null!`);
+        }
+      }
+      ret += `${expressionPrefix}${node.expression}!(${argList.join(', ')})\n`;
+
+      break;
+    }
+  }
+
+  return ret;
 }
 
 function printChildrenType(children: AST_TREE, arrayType?: string): string {

--- a/printer.ts
+++ b/printer.ts
@@ -17,13 +17,19 @@ export function printTree(tree: AST_TREE, interfaceName = "View") {
 }
 
 export function printUse(tree: AST_TREE, realType = "View") {
-  let ret = `const viewInstance = {} as ${realType}\n`;
+  const ret = [
+    `class ${realType}UseChecker extends ${realType} {\n`,
+    '  __useCheckerTestFunc() {\n',
+  ];
   for (const expressionKey of Object.keys(tree)) {
     const node = tree[expressionKey];
-    ret += printNodeUse(node, 'viewInstance.');
+    ret.push(printNodeUse(node, '    ;this.'));
   }
 
-  return ret;
+  ret.push(
+    '  }\n',
+    '}\n');
+  return ret.join('');
 }
 
 function printNodeUse(node: AST_NODE, expressionPrefix = '') {

--- a/printer_test.ts
+++ b/printer_test.ts
@@ -40,7 +40,7 @@ viewInstance.a!
 viewInstance.a!.d!
 viewInstance.a!.f!(null!, null!, null!)
 viewInstance.a!.b!`.trim()
-      )
+      );
   });
 
   it("handles reading prop of list", () => {
@@ -79,7 +79,7 @@ viewInstance.items![0]!.wow!
 viewInstance.items![0]!.foo!.every
 viewInstance.items![0]!.foo![0]!.amaze!
 `.trim()
-    )
+    );
   });
 });
 

--- a/printer_test.ts
+++ b/printer_test.ts
@@ -31,16 +31,19 @@ describe("print use", () => {
         <p>[[a.d]]</p>
         <p>[[a.f(1, 2, a.b)]]</p>
     `), 'FooView'
-      ).trim()).to.deep.equal(
-        `const viewInstance = {} as FooView
-viewInstance.b!
-viewInstance.b!.c!
-viewInstance.b!.c!.d!
-viewInstance.a!
-viewInstance.a!.d!
-viewInstance.a!.f!(null!, null!, null!)
-viewInstance.a!.b!`.trim()
-      );
+      ).trim()).to.deep.equal(`
+class FooViewUseChecker extends FooView {
+  __useCheckerTestFunc() {
+    ;this.b!
+    ;this.b!.c!
+    ;this.b!.c!.d!
+    ;this.a!
+    ;this.a!.d!
+    ;this.a!.f!(null!, null!, null!)
+    ;this.a!.b!
+  }
+}
+    `.trim());
   });
 
   it("handles reading prop of list", () => {
@@ -50,13 +53,16 @@ viewInstance.a!.b!`.trim()
       [[a.people.length]]
       <template is="dom-repeat" items="[[a.people]]">[[item.name]]</template>
     `), 'FooView').trim()
-    ).to.deep.equal(
-      `const viewInstance = {} as FooView
-viewInstance.a!
-viewInstance.a!.people!.every
-viewInstance.a!.people!.length!
-viewInstance.a!.people![0]!.name!`.trim()
-    );
+    ).to.deep.equal(`
+class FooViewUseChecker extends FooView {
+  __useCheckerTestFunc() {
+    ;this.a!
+    ;this.a!.people!.every
+    ;this.a!.people!.length!
+    ;this.a!.people![0]!.name!
+  }
+}
+    `.trim());
   });
 
   it("handles arrays", () => {
@@ -73,13 +79,16 @@ viewInstance.a!.people![0]!.name!`.trim()
     `), 'FooView'
       ).trim()
     ).to.deep.equal(
-      `const viewInstance = {} as FooView
-viewInstance.items!.every
-viewInstance.items![0]!.wow!
-viewInstance.items![0]!.foo!.every
-viewInstance.items![0]!.foo![0]!.amaze!
-`.trim()
-    );
+      `
+class FooViewUseChecker extends FooView {
+  __useCheckerTestFunc() {
+    ;this.items!.every
+    ;this.items![0]!.wow!
+    ;this.items![0]!.foo!.every
+    ;this.items![0]!.foo![0]!.amaze!
+  }
+}
+    `.trim());
   });
 });
 


### PR DESCRIPTION
The first of the two changes below is the result of running ctrl-shift-I to format in VSCode. The second is where all the meat is.