### PR TITLE
Fix output tsconfig generation

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -264,7 +264,7 @@ twinkie --tsconfig tsconfig.json --outdir output_dir [--files file_list] [--outt
         incremental: false,
         noEmit: true,
       },
-      files: [...allProgramFilesNames, generatedFiles],
+      files: [...allProgramFilesNames, ...generatedFiles],
     };
     fs.writeFileSync(
       cmdLineOptions.outputTsConfig,


### PR DESCRIPTION
The generatedFiles is an array and must be expanded when adding to files.